### PR TITLE
Fix insert into schema_seeds with custom seeds_source value from config.

### DIFF
--- a/lib/phil_columns/seed/schema_seed.ex
+++ b/lib/phil_columns/seed/schema_seed.ex
@@ -23,7 +23,7 @@ defmodule PhilColumns.Seed.SchemaSeed do
   end
 
   def up(repo, version) do
-    repo.insert! %__MODULE__{version: version}, @opts
+    repo.insert_all({get_source(repo), __MODULE__}, [%{version: version}], @opts)
   end
 
   def down(repo, version) do

--- a/lib/phil_columns/seed/schema_seed.ex
+++ b/lib/phil_columns/seed/schema_seed.ex
@@ -27,7 +27,7 @@ defmodule PhilColumns.Seed.SchemaSeed do
   end
 
   def down(repo, version) do
-    repo.delete_all from(p in __MODULE__, where: p.version == ^version), @opts
+    repo.delete_all from(p in {get_source(repo), __MODULE__}, where: p.version == ^version), @opts
   end
 
   def get_source(repo) do


### PR DESCRIPTION
Hey, thanks for the great lib!

This PR solves an issue that appears when you set the seeds_source value on the Repo to a custom value. 
With the original code it would use the schema name for the insert and not the value from the config.